### PR TITLE
Make CP4MCM version configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Installation assets for CP4MCM 2.2
+# Installation assets for CP4MCM v2.x
 
-**Note:** This project is provided **AS-IS**. Support will be provided as possible via git issues.
+**Note:** This project is NOT an IBM official project and is provided **AS-IS**. Support will be provided as possible via git issues.
 
-**Updates:**  
+**Updates:** 
+
+04/09/2021
+- Updated the installer to make CP4MCM version configurable: **2.1** or **2.2**, it's your choice.
+
 12/11/2020
 - Updated the installer to work with the latest CP4MCM 2.2 release. 
 
@@ -15,7 +19,7 @@
 
 ## Overview:
 
-This project is designed to provide an automated way to install the Cloud Pak for Multicloud Management (CP4MCM) v2.1.
+This project is designed to provide an automated way to install the Cloud Pak for Multicloud Management (CP4MCM) v2.x.
 
 ### Scope:
 
@@ -72,6 +76,15 @@ $ cat > _customization.sh <<EOF
 #
 export ENTITLED_REGISTRY_USER="cp"
 export ENTITLED_REGISTRY_KEY="<YOUR LONG ENTITLEMENT KEY GOES HERE>"
+
+#
+# Cloud Pak Version, defaults to 2.2 if not set
+#
+# There are some implications while picking the version. For example:
+# - In CP4MCM v2.1.x: the RHACM, once enabled, will be v2.0
+# - In CP4MCM v2.2.x: the RHACM, once enabled, will be v2.1
+#
+export CP4MCM_VERSION="2.2"
 
 #
 # Cloud Pak Modules to enable or disable:

--- a/cp4m/cp4mcm-install.sh
+++ b/cp4m/cp4mcm-install.sh
@@ -6,6 +6,7 @@ source setup_env.sh
 log  "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 log  "Installation is starting with the following configuration:"
 log  " ROKS                               = $ROKS"
+log  " CP4MCM Version                     = $CP4MCM_VERSION"
 log  " CP4MCM Namespace                   = $CP4MCM_NAMESPACE"
 log  " Block Storage Class                = $CP4MCM_BLOCK_STORAGECLASS"
 log  " File Storage Class                 = $CP4MCM_FILE_STORAGECLASS"
@@ -58,7 +59,7 @@ spec:
   displayName: IBMCS Operators
   publisher: IBM
   sourceType: grpc
-  image: docker.io/ibmcom/ibm-common-service-catalog:3.5.6
+  image: docker.io/ibmcom/ibm-common-service-catalog:${CS_VERSION}
   updateStrategy:
     registryPoll:
       interval: 45m
@@ -81,7 +82,7 @@ spec:
   displayName: IBM Management Orchestrator Catalog
   publisher: IBM
   sourceType: grpc
-  image: quay.io/cp4mcm/cp4mcm-orchestrator-catalog:2.2-latest
+  image: quay.io/cp4mcm/cp4mcm-orchestrator-catalog:${CP4MCM_VERSION}-latest
   updateStrategy:
     registryPoll:
       interval: 45m
@@ -108,12 +109,12 @@ metadata:
   name: ibm-management-orchestrator
   namespace: openshift-operators
 spec:
-  channel: 2.2-stable
+  channel: ${CP4MCM_SUBSCRIPTION_CHANNEL}
   installPlanApproval: Automatic
   name: ibm-management-orchestrator
   source: ibm-management-orchestrator
   sourceNamespace: openshift-marketplace
-  startingCSV: ibm-management-orchestrator.v2.2.5
+  startingCSV: ibm-management-orchestrator.v${CP4MCM_SUBSCRIPTION_CSV}
 EOF
 
 #
@@ -125,7 +126,7 @@ progress-bar 180
 #
 # Create the Installation
 #
-log "Applying the CP4MCM 2.2 - Core Installation"
+log "Applying the CP4MCM ${CP4MCM_VERSION} - Core Installation"
 cat << EOF | oc apply -f -
 apiVersion: orchestrator.management.ibm.com/v1alpha1
 kind: Installation

--- a/cp4m/ldap.sh
+++ b/cp4m/ldap.sh
@@ -76,6 +76,7 @@ execlog cloudctl iam ldap-create my_ldap --basedn 'dc=ibm,dc=com' --binddn 'cn=a
 execlog cloudctl iam team-create operations
 execlog cloudctl iam group-import --group operations -f
 execlog cloudctl iam team-add-groups operations Administrator -g operations
+execlog cloudctl iam resource-add operations -r "crn:v1:icp:private:k8:mycluster:n/default:::"
 
 #
 # List out what users in "operations" group that we've imported

--- a/rhacm/1-rhacm.sh
+++ b/rhacm/1-rhacm.sh
@@ -42,7 +42,7 @@ metadata:
 spec:
   sourceNamespace: openshift-marketplace
   source: redhat-operators
-  channel: release-2.1
+  channel: release-${RHACM_VERSION}
   installPlanApproval: Automatic
   name: advanced-cluster-management
 EOF
@@ -56,7 +56,7 @@ progress-bar 180
 #
 # Create the Installation
 #
-log "Applying the RHACM 2.1 - Multiclusterhub Installation"
+log "Applying the RHACM ${RHACM_VERSION} - Multiclusterhub Installation"
 
 if [ "${RED_HAT_PULL_SECRET_PATH}" ]; then 
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -23,6 +23,24 @@ export ENTITLED_REGISTRY_SECRET="ibm-management-pull-secret"
 export DOCKER_EMAIL="myemail@ibm.com"
 
 #
+# CP4MCM versioning with relevant components
+#
+export CP4MCM_VERSION="${CP4MCM_VERSION:-2.2}"
+if [[ "${CP4MCM_VERSION}" == "2.2" ]]; then 
+  export CS_VERSION="3.5.6"
+  export CP4MCM_SUBSCRIPTION_CHANNEL="2.2-stable"
+  export CP4MCM_SUBSCRIPTION_CSV="2.2.5"
+  export RHACM_VERSION="2.1"
+elif  [[ "${CP4MCM_VERSION}" == "2.1" ]]; then 
+  export CS_VERSION="3.5.6"
+  export CP4MCM_SUBSCRIPTION_CHANNEL="2.1-stable"
+  export CP4MCM_SUBSCRIPTION_CSV="2.1.5"
+  export RHACM_VERSION="2.0"
+else
+  echo "The CP4MCM version is not supported by this script: ${CP4MCM_VERSION}"; exit 999;
+fi
+
+#
 # Define you storage classes here. If you are running on ROKS or using OCS it should be 
 # able to figure it out, but if you want something custom you can specify that here.
 #


### PR DESCRIPTION
This PR makes the CP4MCM version configurable. So CP4MCM v2.1 or v2.2, it's your choice.

Meanwhile, I've fixed a issue by adding the "default" namespace as the `operations` group's resource to avoid the potential issue in GRC: when no resources have been assigned to the group, there is no namespace to host policies so it's no way to create GRC policies.