### PR TITLE
Patch CAM tls, fix mc config and enhance logging timestamp

### DIFF
--- a/cp4m/cp4mcm-post-install.sh
+++ b/cp4m/cp4mcm-post-install.sh
@@ -19,7 +19,7 @@ then
 fi
 
 #
-# Updating Installation config with CAM config.
+# IM post actions
 #
 if [[ "$CP4MCM_INFRASTRUCTUREMANAGEMENT_ENABLED" == "true" ]];
 then
@@ -28,6 +28,12 @@ then
     #
     log "Integrating CP4MCM IAM with LDAP"
     ./cp4m/CloudFormsandOIDC.sh
+
+    #
+    # Patching CAM
+    #
+    log "Patching CP4MCM IM's CAM"
+    ./cp4m/patch-im-cam.sh
 fi
 
 

--- a/cp4m/patch-im-cam.sh
+++ b/cp4m/patch-im-cam.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+source lib/functions.sh
+
+# Prepare CAM route
+CAM_ROUTE=`oc -n ibm-common-services get route cp-console --template '{{.spec.host}}' | sed s/cp-console/cam/`
+
+# Patching CAM cert
+# oc get -n management-infrastructure-management cert/cert -o yaml
+log "Patching CAM cert"
+oc patch Certificate cert --type "json" -n management-infrastructure-management \
+    -p "[
+        {\"op\":\"add\",\"path\":\"/spec/dnsNames/-\",\"value\":\"${CAM_ROUTE}\"},
+        {\"op\":\"add\",\"path\":\"/spec/duration\",\"value\":\"8760h0m0s\"},
+        {\"op\":\"add\",\"path\":\"/spec/usages\",\"value\":[\"digital signature\",\"key encipherment\",\"server auth\"]}
+    ]"

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -3,8 +3,7 @@
 ###################################################
 
 function log {
-    echo "$(date): $@"
-    echo "$(date): $@" >> $LOGFILE
+    echo "$(date +"%Y-%m-%d %H:%m:%S"): $@" | tee -a $LOGFILE
 }
 
 

--- a/rhacm/2-minio.sh
+++ b/rhacm/2-minio.sh
@@ -55,11 +55,15 @@ if [ -x "$(command -v mc)" ]; then
   minio_accesskey=`oc -n $MINIO_NAMESPACE get secret minio -o json | jq -r .data.accesskey | base64 -d`
   minio_secretkey=`oc -n $MINIO_NAMESPACE get secret minio -o json | jq -r .data.secretkey | base64 -d`
   mc config host rm minio
-  mc config host add minio http://localhost:9000 $minio_accesskey $minio_secretkey --api "s3v4" --lookup "dns"
+  mc config host add minio http://localhost:9000 $minio_accesskey $minio_secretkey --api "s3v4"
 
-  mc ls minio
+  # copy a file
+  mc cp README.md minio/rhacm-bucket
+
+  # list the folder
+  mc ls -r minio
   # we should see somethihg like
-  #[2021-04-29 11:35:20 +08]      0B rhacm-bucket/
+  #[2021-05-05 10:44:42 +08]    133B rhacm-bucket/README.md
 
   # kill port-forward process
   kill -9 $port_forward_pid


### PR DESCRIPTION
This PR brings in below changes:

1. added a patch for CAM tls to avoid CAM access issue in browsers like Chrome;
2. used a better timestamp while logging;
3. fixed `mc config` to avoid DNS issue while trying locally by commands like `mc cp`.
