### PR TITLE
use an explicit CR to reduce the CS footprint

### DIFF
--- a/cp4m/CloudFormsandOIDC.sh
+++ b/cp4m/CloudFormsandOIDC.sh
@@ -60,7 +60,7 @@ execlog cloudctl iam oauth-client-register -f registration.json
 # Create imconnectionsecret
 #
 log "Creating imconnectionsecret."
-oc create -f - <<EOF
+oc apply -f - <<EOF
 kind: Secret                                                                                                     
 apiVersion: v1                                                                                                   
 metadata:                                                                                                        

--- a/cp4m/CloudFormsandOIDC.sh
+++ b/cp4m/CloudFormsandOIDC.sh
@@ -140,7 +140,7 @@ EOF
 # Create IMInstall
 #
 log "Creating CloudForms IMInstall"
-oc create -f - <<EOF
+oc apply -f - <<EOF
 apiVersion: infra.management.ibm.com/v1alpha1
 kind: IMInstall
 metadata:
@@ -172,7 +172,7 @@ log "Creating IM Connection Resource"
 #
 # Create Connection
 #
-oc create -f - <<EOF
+oc apply -f - <<EOF
  apiVersion: infra.management.ibm.com/v1alpha1
  kind: Connection
  metadata:

--- a/cp4m/cp4mcm-install.sh
+++ b/cp4m/cp4mcm-install.sh
@@ -111,27 +111,6 @@ spec:
 EOF
 
 #
-# Creating Common Services CR
-# 
-# To further customize Common Services, check this out:
-# https://www.ibm.com/docs/en/cloud-paks/cp-management/2.3.x?topic=configuration-configuring-common-services
-#
-# log "Creating Common Services CR"
-# oc apply -f - <<EOF
-# apiVersion: operator.ibm.com/v3
-# kind: CommonService
-# metadata:
-#   name: common-service
-#   namespace: ibm-common-services
-# spec:
-#   size: medium
-# EOF
-
-# log "Waiting for Common Services' CR to be ready (180 seconds)"
-# progress-bar 180
-
-
-#
 # Creating CP4MCM CatalogSource
 #
 log "Creating CP4MCM CatalogSource"
@@ -174,6 +153,18 @@ EOF
 # Waiting for both Common Services and CP4MCM Subscription to be ready
 #
 log "Waiting for both Common Services and CP4MCM Subscription to be ready (180 seconds)"
+progress-bar 180
+
+#
+# Creating Common Services CR
+# 
+# To further customize Common Services, check this out:
+# https://www.ibm.com/docs/en/cloud-paks/cp-management/2.3.x?topic=configuration-configuring-common-services
+#
+log "Creating Common Services CR"
+oc apply -f yaml/common-services.yaml
+
+log "Waiting for Common Services' CR to be ready (180 seconds)"
 progress-bar 180
 
 #

--- a/yaml/common-services.yaml
+++ b/yaml/common-services.yaml
@@ -43,13 +43,13 @@ spec:
   - name: ibm-mongodb-operator
     spec:
       mongoDB:
-        replicas: 3
+        replicas: 1
         resources:
           limits:
             cpu: 2000m
             memory: 5368Mi
           requests:
-            cpu: 1500m
+            cpu: 1000m
             memory: 5368Mi
   - name: ibm-iam-operator
     spec:

--- a/yaml/common-services.yaml
+++ b/yaml/common-services.yaml
@@ -1,0 +1,455 @@
+apiVersion: operator.ibm.com/v3
+kind: CommonService
+metadata:
+  name: common-service
+  namespace: ibm-common-services
+spec:
+  services:
+  - name: ibm-cert-manager-operator
+    spec:
+      certManager:
+        certManagerCAInjector:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 525Mi
+            requests:
+              cpu: 100m
+              memory: 315Mi
+        certManagerController:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 525Mi
+            requests:
+              cpu: 100m
+              memory: 315Mi
+        certManagerWebhook:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 525Mi
+            requests:
+              cpu: 100m
+              memory: 315Mi
+        configMapWatcher:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 525Mi
+            requests:
+              cpu: 100m
+              memory: 315Mi
+  - name: ibm-mongodb-operator
+    spec:
+      mongoDB:
+        replicas: 3
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 5368Mi
+          requests:
+            cpu: 1500m
+            memory: 5368Mi
+  - name: ibm-iam-operator
+    spec:
+      authentication:
+        replicas: 1
+        auditService:
+          resources:
+            limits:
+              cpu: 100m
+              memory: 134Mi
+            requests:
+              cpu: 10m
+              memory: 104Mi
+        authService:
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1073Mi
+            requests:
+              cpu: 100m
+              memory: 367Mi
+        clientRegistration:
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1073Mi
+            requests:
+              cpu: 100m
+              memory: 134Mi
+        identityManager:
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1073Mi
+            requests:
+              cpu: 50m
+              memory: 157Mi
+        identityProvider:
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1073Mi
+            requests:
+              cpu: 50m
+              memory: 157Mi
+      oidcclientwatcher:
+        replicas: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 268Mi
+          requests:
+            cpu: 10m
+            memory: 17Mi
+      pap:
+        auditService:
+          resources:
+            limits:
+              cpu: 200m
+              memory: 209Mi
+            requests:
+              cpu: 20m
+              memory: 20Mi
+        papService:
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1073Mi
+            requests:
+              cpu: 50m
+              memory: 209Mi
+        replicas: 1
+      policycontroller:
+        replicas: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 402Mi
+          requests:
+            cpu: 100m
+            memory: 134Mi
+      policydecision:
+        auditService:
+          resources:
+            limits:
+              cpu: 200m
+              memory: 268Mi
+            requests:
+              cpu: 10m
+              memory: 104Mi
+        resources:
+          limits:
+            cpu: 200m
+            memory: 268Mi
+          requests:
+            cpu: 20m
+            memory: 104Mi
+        replicas: 1
+      secretwatcher:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 536Mi
+          requests:
+            cpu: 50m
+            memory: 67Mi
+        replicas: 1
+      securityonboarding:
+        replicas: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 536Mi
+          requests:
+            cpu: 20m
+            memory: 67Mi
+        iamOnboarding:
+          resources:
+            limits:
+              cpu: 200m
+              memory: 1073Mi
+            requests:
+              cpu: 20m
+              memory: 67Mi
+  - name: ibm-management-ingress-operator
+    spec:
+      managementIngress:
+        replicas: 1
+        resources:
+          requests:
+            cpu: 50m
+            memory: 314Mi
+          limits:
+            cpu: 200m
+            memory: 536Mi
+  - name: ibm-ingress-nginx-operator
+    spec:
+      nginxIngress:
+        ingress:
+          replicas: 1
+          resources:
+            requests:
+              cpu: 50m
+              memory: 157Mi
+            limits:
+              cpu: 200m
+              memory: 536Mi
+        defaultBackend:
+          replicas: 1
+          resources:
+            requests:
+              cpu: 20m
+              memory: 67Mi
+            limits:
+              cpu: 50m
+              memory: 134Mi
+        kubectl:
+          resources:
+            requests:
+              memory: 150Mi
+              cpu: 30m
+            limits:
+              memory: 256Mi
+              cpu: 100m
+  - name: ibm-metering-operator
+    spec:
+      metering:
+        dataManager:
+          dm:
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 2684Mi
+              requests:
+                cpu: 100m
+                memory: 268Mi
+        reader:
+          rdr:
+            resources:
+              limits:
+                cpu: 500m
+                memory: 536Mi
+              requests:
+                cpu: 100m
+                memory: 134Mi
+      meteringReportServer:
+        reportServer:
+          resources:
+            limits:
+              cpu: 100m
+              memory: 90Mi
+            requests:
+              cpu: 50m
+              memory: 65Mi
+      meteringUI:
+        replicas: 1
+        ui:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 536Mi
+            requests:
+              cpu: 100m
+              memory: 134Mi
+  - name: ibm-licensing-operator
+    spec:
+      IBMLicensing:
+        resources:
+          requests:
+            cpu: 200m
+            memory: 268Mi
+          limits:
+            cpu: 500m
+            memory: 536Mi
+      IBMLicenseServiceReporter:
+        databaseContainer:
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 300m
+              memory: 300Mi
+        receiverContainer:
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 300m
+              memory: 300Mi
+  - name: ibm-commonui-operator
+    spec:
+      commonWebUI:
+        replicas: 1
+        resources:
+          requests:
+            memory: 268Mi
+            cpu: 450m
+          limits:
+            memory: 268Mi
+            cpu: 1000m
+  - name: ibm-platform-api-operator
+    spec:
+      platformApi:
+        auditService:
+          resources:
+            limits:
+              cpu: 200m
+              memory: 262Mi
+            requests:
+              cpu: 200m
+              memory: 262Mi
+        platformApi:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 536Mi
+            requests:
+              cpu: 500m
+              memory: 536Mi
+        replicas: 1
+  - name: ibm-healthcheck-operator
+    spec:
+      healthService:
+        memcached:
+          replicas: 1
+          resources:
+            requests:
+              memory: 67Mi
+              cpu: 50m
+            limits:
+              memory: 536Mi
+              cpu: 500m
+        healthService:
+          replicas: 1
+          resources:
+            requests:
+              memory: 67Mi
+              cpu: 50m
+            limits:
+              memory: 536Mi
+              cpu: 500m
+  - name: ibm-auditlogging-operator
+    spec:
+      auditLogging:
+        fluentd:
+          resources:
+            requests:
+              cpu: 25m
+              memory: 104Mi
+            limits:
+              cpu: 300m
+              memory: 419Mi
+  - name: ibm-monitoring-exporters-operator
+    spec:
+      exporter:
+        collectd:
+          resource:
+            requests:
+              cpu: 30m
+              memory: 50Mi
+            limits:
+              cpu: 30m
+              memory: 50Mi
+          routerResource:
+            limits:
+              cpu: 200m
+              memory: 268Mi
+            requests:
+              cpu: 10m
+              memory: 67Mi
+        nodeExporter:
+          resource:
+            requests:
+              cpu: 20m
+              memory: 50Mi
+            limits:
+              cpu: 20m
+              memory: 50Mi
+          routerResource:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+        kubeStateMetrics:
+          resource:
+            requests:
+              cpu: 500m
+              memory: 180Mi
+            limits:
+              cpu: 540m
+              memory: 220Mi
+          routerResource:
+            limits:
+              cpu: 25m
+              memory: 50Mi
+            requests:
+              cpu: 20m
+              memory: 50Mi
+  - name: ibm-monitoring-grafana-operator
+    spec:
+      grafana:
+        grafanaConfig:
+          resources:
+            requests:
+              cpu: 400m
+              memory: 230Mi
+            limits:
+              cpu: 1073m
+              memory: 536Mi
+        dashboardConfig:
+          resources:
+            requests:
+              cpu: 200m
+              memory: 268Mi
+            limits:
+              cpu: 500m
+              memory: 536Mi
+        routerConfig:
+          resources:
+            requests:
+              cpu: 200m
+              memory: 268Mi
+            limits:
+              cpu: 500m
+              memory: 536Mi
+  - name: ibm-monitoring-prometheusext-operator
+    spec:
+      prometheusExt:
+        prometheusConfig:
+          routerResource:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+            limits:
+              cpu: 75m
+              memory: 50Mi
+          resource:
+            requests:
+              cpu: 200m
+              memory: 3072Mi
+            limits:
+              cpu: 1000m
+              memory: 5120Mi
+        alertManagerConfig:
+          resource:
+            requests:
+              cpu: 20m
+              memory: 134Mi
+            limits:
+              cpu: 30m
+              memory: 200Mi
+        mcmMonitor:
+          resource:
+            requests:
+              cpu: 30m
+              memory: 50Mi
+            limits:
+              cpu: 50m
+              memory: 50Mi


### PR DESCRIPTION
Just retried deploying only IM and found some issues when using the default `medium` CommonService CR.
But using the small size one from the example yaml worked smoothly: https://www.ibm.com/docs/en/cloud-paks/cp-management/2.3.x?topic=installation-apply-custom-yaml-small-common-services-environment